### PR TITLE
Feature/week8 kafka

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -1,37 +1,38 @@
 dependencies {
-    // add-ons
+    // 추가 모듈
     implementation(project(":modules:jpa"))
+    implementation(project(":modules:kafka"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
 
-    // web
+    // 웹
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
     
-    // cache (Redis)
+    // 캐시 (Redis)
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-cache")
     
-    // resilience4j
+    // 회복력 제어 (resilience4j)
     implementation("io.github.resilience4j:resilience4j-spring-boot3")
     implementation("org.springframework.boot:spring-boot-starter-aop")
     
-    // feign client
+    // HTTP 클라이언트 (feign)
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
-    // querydsl
+    // 쿼리 DSL
 //    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
 //    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 //    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
-    // test-fixtures
+    // 테스트 픽스처
     testImplementation(testFixtures(project(":modules:jpa")))
     
-    // mock web server for external API testing
+    // 외부 API 테스트용 목 웹서버
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     
-    // awaitility for async testing
+    // 비동기 테스트용 대기 유틸리티
     testImplementation("org.awaitility:awaitility:4.2.0")
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/event/KafkaEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/event/KafkaEventHandler.java
@@ -1,0 +1,137 @@
+package com.loopers.application.event;
+
+import com.loopers.application.product.ProductFacade;
+import com.loopers.domain.event.CatalogEvent;
+import com.loopers.domain.event.OrderEvent;
+import com.loopers.domain.like.ProductLikeEvent;
+import com.loopers.domain.order.OrderCreatedEvent;
+import com.loopers.domain.payment.PaymentResultEvent;
+import com.loopers.infrastructure.event.KafkaEventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+/**
+ * 스프링 애플리케이션 이벤트를 카프카 이벤트로 변환
+ */
+@Component
+public class KafkaEventHandler {
+    private static final Logger log = LoggerFactory.getLogger(KafkaEventHandler.class);
+    
+    private final KafkaEventPublisher kafkaEventPublisher;
+
+    public KafkaEventHandler(KafkaEventPublisher kafkaEventPublisher) {
+        this.kafkaEventPublisher = kafkaEventPublisher;
+    }
+
+    /**
+     * ProductLikeEvent를 처리하여 catalog-events 토픽으로 전송
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductLikeEvent(ProductLikeEvent event) {
+        try {
+            CatalogEvent catalogEvent;
+            if (event.isLiked()) {
+                catalogEvent = CatalogEvent.productLiked(
+                    event.getProductId(), 
+                    event.getUserId(), 
+                    event.getTimestamp().toEpochSecond()
+                );
+            } else {
+                catalogEvent = CatalogEvent.productUnliked(
+                    event.getProductId(), 
+                    event.getUserId(), 
+                    event.getTimestamp().toEpochSecond()
+                );
+            }
+            
+            kafkaEventPublisher.publishCatalogEvent(catalogEvent);
+            
+        } catch (Exception e) {
+            log.error("Failed to handle ProductLikeEvent: {}", event, e);
+            // 재시도 로직이나 데드 레터 큐 구현 고려
+        }
+    }
+
+    /**
+     * OrderCreatedEvent를 처리하여 order-events 토픽으로 전송
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCreatedEvent(OrderCreatedEvent event) {
+        try {
+            // 데모용으로 샘플 주문 항목 생성
+            // 실제 시나리오에서는 주문과 주문 항목을 조회해야 함
+            List<OrderEvent.OrderItemData> items = List.of(
+                // 여기에서 실제 주문 항목을 로드해야 함
+            );
+            
+            OrderEvent orderEvent = OrderEvent.orderCreated(
+                event.getOrderId(),
+                event.getUserId(),
+                event.getTotalAmount(),
+                event.getCouponId(),
+                event.getCardCompany(),
+                event.getCardNumber(),
+                items
+            );
+            
+            kafkaEventPublisher.publishOrderEvent(orderEvent);
+            
+        } catch (Exception e) {
+            log.error("Failed to handle OrderCreatedEvent: {}", event, e);
+            // 재시도 로직이나 데드 레터 큐 구현 고려
+        }
+    }
+
+    /**
+     * PaymentResultEvent를 처리하여 order-events 토픽으로 전송
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentResultEvent(PaymentResultEvent event) {
+        try {
+            OrderEvent orderEvent = OrderEvent.paymentProcessed(
+                Long.parseLong(event.getOrderId()),
+                event.getTransactionId(),
+                event.getAmount(),
+                event.getStatus().toString(),
+                event.getFailureReason()
+            );
+            
+            kafkaEventPublisher.publishOrderEvent(orderEvent);
+            
+        } catch (Exception e) {
+            log.error("Failed to handle PaymentResultEvent: {}", event, e);
+            // 재시도 로직이나 데드 레터 큐 구현 고려
+        }
+    }
+
+    /**
+     * 재고 조정 이벤트 처리
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockAdjustedEvent(ProductFacade.StockAdjustedEvent event) {
+        try {
+            CatalogEvent catalogEvent = CatalogEvent.stockAdjusted(
+                event.getProductId(), 
+                event.getQuantityChanged(), 
+                System.currentTimeMillis()
+            );
+            
+            kafkaEventPublisher.publishCatalogEvent(catalogEvent);
+            
+        } catch (Exception e) {
+            log.error("Failed to handle stock adjustment for productId: {}, quantity: {}", 
+                event.getProductId(), event.getQuantityChanged(), e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/CatalogEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/CatalogEvent.java
@@ -1,0 +1,72 @@
+package com.loopers.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 카탈로그 관련 변경사항(제품, 좋아요 등)에 대한 도메인 이벤트
+ */
+public class CatalogEvent {
+    private String eventId;
+    private String eventType;
+    private Long productId;
+    private String userId;
+    private Long timestamp;
+    private Integer quantityChanged;
+    private Long version;
+
+    // 빌더 패턴을 위한 private 생성자
+    private CatalogEvent() {
+        this.eventId = UUID.randomUUID().toString();
+        this.version = System.currentTimeMillis();
+    }
+
+    public static CatalogEvent productLiked(Long productId, String userId, Long timestamp) {
+        CatalogEvent event = new CatalogEvent();
+        event.eventType = "PRODUCT_LIKED";
+        event.productId = productId;
+        event.userId = userId;
+        event.timestamp = timestamp;
+        return event;
+    }
+
+    public static CatalogEvent productUnliked(Long productId, String userId, Long timestamp) {
+        CatalogEvent event = new CatalogEvent();
+        event.eventType = "PRODUCT_UNLIKED";
+        event.productId = productId;
+        event.userId = userId;
+        event.timestamp = timestamp;
+        return event;
+    }
+
+    public static CatalogEvent stockAdjusted(Long productId, Integer quantityChanged, Long timestamp) {
+        CatalogEvent event = new CatalogEvent();
+        event.eventType = "STOCK_ADJUSTED";
+        event.productId = productId;
+        event.quantityChanged = quantityChanged;
+        event.timestamp = timestamp;
+        return event;
+    }
+
+    // Getter 메서드들
+    public String getEventId() { return eventId; }
+    public String getEventType() { return eventType; }
+    public Long getProductId() { return productId; }
+    public String getUserId() { return userId; }
+    public Long getTimestamp() { return timestamp; }
+    public Integer getQuantityChanged() { return quantityChanged; }
+    public Long getVersion() { return version; }
+
+    @Override
+    public String toString() {
+        return "CatalogEvent{" +
+                "eventId='" + eventId + '\'' +
+                ", eventType='" + eventType + '\'' +
+                ", productId=" + productId +
+                ", userId='" + userId + '\'' +
+                ", timestamp=" + timestamp +
+                ", quantityChanged=" + quantityChanged +
+                ", version=" + version +
+                '}';
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/event/OrderEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/event/OrderEvent.java
@@ -1,0 +1,106 @@
+package com.loopers.domain.event;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 주문 관련 변경사항에 대한 도메인 이벤트
+ */
+public class OrderEvent {
+    private String eventId;
+    private String eventType;
+    private Long orderId;
+    private String userId;
+    private BigDecimal totalAmount;
+    private Long couponId;
+    private String cardCompany;
+    private String cardNumber;
+    private List<OrderItemData> items;
+    private String transactionId;
+    private String paymentStatus;
+    private String failureReason;
+    private Long timestamp;
+    private Long version;
+
+    // 빌더 패턴을 위한 private 생성자
+    private OrderEvent() {
+        this.eventId = UUID.randomUUID().toString();
+        this.timestamp = System.currentTimeMillis();
+        this.version = System.currentTimeMillis();
+    }
+
+    public static OrderEvent orderCreated(Long orderId, String userId, BigDecimal totalAmount, 
+                                        Long couponId, String cardCompany, String cardNumber,
+                                        List<OrderItemData> items) {
+        OrderEvent event = new OrderEvent();
+        event.eventType = "ORDER_CREATED";
+        event.orderId = orderId;
+        event.userId = userId;
+        event.totalAmount = totalAmount;
+        event.couponId = couponId;
+        event.cardCompany = cardCompany;
+        event.cardNumber = cardNumber;
+        event.items = items;
+        return event;
+    }
+
+    public static OrderEvent paymentProcessed(Long orderId, String transactionId, BigDecimal amount,
+                                            String paymentStatus, String failureReason) {
+        OrderEvent event = new OrderEvent();
+        event.eventType = "PAYMENT_PROCESSED";
+        event.orderId = orderId;
+        event.transactionId = transactionId;
+        event.totalAmount = amount;
+        event.paymentStatus = paymentStatus;
+        event.failureReason = failureReason;
+        return event;
+    }
+
+    // 주문 항목을 위한 내부 클래스
+    public static class OrderItemData {
+        private Long productId;
+        private Integer quantity;
+        private BigDecimal price;
+
+        public OrderItemData(Long productId, Integer quantity, BigDecimal price) {
+            this.productId = productId;
+            this.quantity = quantity;
+            this.price = price;
+        }
+
+        // Getter 메서드들
+        public Long getProductId() { return productId; }
+        public Integer getQuantity() { return quantity; }
+        public BigDecimal getPrice() { return price; }
+    }
+
+    // Getter 메서드들
+    public String getEventId() { return eventId; }
+    public String getEventType() { return eventType; }
+    public Long getOrderId() { return orderId; }
+    public String getUserId() { return userId; }
+    public BigDecimal getTotalAmount() { return totalAmount; }
+    public Long getCouponId() { return couponId; }
+    public String getCardCompany() { return cardCompany; }
+    public String getCardNumber() { return cardNumber; }
+    public List<OrderItemData> getItems() { return items; }
+    public String getTransactionId() { return transactionId; }
+    public String getPaymentStatus() { return paymentStatus; }
+    public String getFailureReason() { return failureReason; }
+    public Long getTimestamp() { return timestamp; }
+    public Long getVersion() { return version; }
+
+    @Override
+    public String toString() {
+        return "OrderEvent{" +
+                "eventId='" + eventId + '\'' +
+                ", eventType='" + eventType + '\'' +
+                ", orderId=" + orderId +
+                ", userId='" + userId + '\'' +
+                ", totalAmount=" + totalAmount +
+                ", timestamp=" + timestamp +
+                ", version=" + version +
+                '}';
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/KafkaEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/KafkaEventPublisher.java
@@ -1,0 +1,68 @@
+package com.loopers.infrastructure.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.event.CatalogEvent;
+import com.loopers.domain.event.OrderEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 카프카 토픽에 이벤트를 발행하기 위한 인프라 서비스
+ */
+@Component
+public class KafkaEventPublisher {
+    private static final Logger log = LoggerFactory.getLogger(KafkaEventPublisher.class);
+    
+    private static final String CATALOG_EVENTS_TOPIC = "catalog-events";
+    private static final String ORDER_EVENTS_TOPIC = "order-events";
+    
+    private final KafkaTemplate<Object, Object> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public KafkaEventPublisher(KafkaTemplate<Object, Object> kafkaTemplate, ObjectMapper objectMapper) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public void publishCatalogEvent(CatalogEvent event) {
+        try {
+            String eventJson = objectMapper.writeValueAsString(event);
+            String partitionKey = event.getProductId().toString();
+            
+            kafkaTemplate.send(CATALOG_EVENTS_TOPIC, partitionKey, eventJson)
+                    .whenComplete((result, ex) -> {
+                        if (ex != null) {
+                            log.error("Failed to publish catalog event: {}", event, ex);
+                        } else {
+                            log.info("Successfully published catalog event: {} to partition: {}", 
+                                    event.getEventId(), result.getRecordMetadata().partition());
+                        }
+                    });
+                    
+        } catch (Exception e) {
+            log.error("Failed to serialize catalog event: {}", event, e);
+        }
+    }
+
+    public void publishOrderEvent(OrderEvent event) {
+        try {
+            String eventJson = objectMapper.writeValueAsString(event);
+            String partitionKey = event.getOrderId().toString();
+            
+            kafkaTemplate.send(ORDER_EVENTS_TOPIC, partitionKey, eventJson)
+                    .whenComplete((result, ex) -> {
+                        if (ex != null) {
+                            log.error("Failed to publish order event: {}", event, ex);
+                        } else {
+                            log.info("Successfully published order event: {} to partition: {}", 
+                                    event.getEventId(), result.getRecordMetadata().partition());
+                        }
+                    });
+                    
+        } catch (Exception e) {
+            log.error("Failed to serialize order event: {}", event, e);
+        }
+    }
+}

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -5,20 +5,30 @@ plugins {
 }
 
 dependencies {
-    // add-ons
+    // 추가 모듈
     implementation(project(":modules:jpa"))
     implementation(project(":modules:kafka"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))
 
-    // web
+    // 웹
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    
+    // 캐시 (Redis)
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
 
-    // querydsl
+    // 쿼리 DSL
     kapt("com.querydsl:querydsl-apt::jakarta")
 
-    // test-fixtures
+    // 테스트 픽스처
     testImplementation(testFixtures(project(":modules:jpa")))
+    
+    // 카프카 테스트
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    
+    // 비동기 테스트용 대기 유틸리티
+    testImplementation("org.awaitility:awaitility:4.2.0")
 }

--- a/apps/commerce-streamer/build.gradle.kts
+++ b/apps/commerce-streamer/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    kotlin("jvm") version "2.0.20"
+    kotlin("kapt") version "2.0.20" 
+    kotlin("plugin.jpa") version "2.0.20"
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:kafka"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/config/RedisConfig.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.loopers.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * 캐시 관리를 위한 Redis 설정
+ */
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        
+        // 키에 대해 String 시리얼라이저 사용
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        
+        // 값에 대해 JSON 시리얼라이저 사용
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        
+        template.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+        template.afterPropertiesSet();
+        
+        return template;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/consumer/AuditLogConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/consumer/AuditLogConsumer.java
@@ -1,0 +1,125 @@
+package com.loopers.consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.config.kafka.KafkaConfig;
+import com.loopers.domain.event.EventHandled;
+import com.loopers.domain.event.EventLog;
+import com.loopers.repository.EventLogRepository;
+import com.loopers.service.IdempotentEventService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * 모든 이벤트를 감사 로그 테이블에 기록하는 컨슈머
+ * 처리된 모든 이벤트의 완전한 감사 추적을 제공합니다
+ */
+@Component
+public class AuditLogConsumer {
+    
+    private static final Logger log = LoggerFactory.getLogger(AuditLogConsumer.class);
+    
+    private final EventLogRepository eventLogRepository;
+    private final IdempotentEventService idempotentEventService;
+    private final ObjectMapper objectMapper;
+
+    public AuditLogConsumer(EventLogRepository eventLogRepository,
+                           IdempotentEventService idempotentEventService,
+                           ObjectMapper objectMapper) {
+        this.eventLogRepository = eventLogRepository;
+        this.idempotentEventService = idempotentEventService;
+        this.objectMapper = objectMapper;
+    }
+    
+    @KafkaListener(
+        topics = {"catalog-events", "order-events"},
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+        groupId = "audit-log-consumer-group"
+    )
+    @Transactional
+    public void auditEventListener(List<ConsumerRecord<String, JsonNode>> messages, 
+                                  Acknowledgment acknowledgment) {
+        log.info("Processing {} events for audit logging", messages.size());
+        
+        int processedCount = 0;
+        int skippedCount = 0;
+        
+        try {
+            for (ConsumerRecord<String, JsonNode> message : messages) {
+                JsonNode eventData = message.value();
+                String eventId = eventData.has("eventId") ? eventData.get("eventId").asText() : null;
+                String eventType = eventData.has("eventType") ? eventData.get("eventType").asText() : null;
+                Long version = eventData.has("version") ? eventData.get("version").asLong() : null;
+                
+                if (eventId == null || eventType == null) {
+                    log.warn("Skipping invalid event - missing eventId or eventType: {}", eventData);
+                    skippedCount++;
+                    continue;
+                }
+                
+                boolean processed = idempotentEventService.processEventIdempotent(
+                    eventId,
+                    EventHandled.ConsumerType.AUDIT_LOG,
+                    version,
+                    () -> saveEventLog(message, eventId, eventType, eventData, version)
+                );
+                
+                if (processed) {
+                    processedCount++;
+                    log.debug("Audit logged event: eventId={}, eventType={}", eventId, eventType);
+                } else {
+                    skippedCount++;
+                    log.debug("Skipped duplicate event: eventId={}, eventType={}", eventId, eventType);
+                }
+            }
+            
+            // 성공적인 처리 후 수동 확인응답
+            acknowledgment.acknowledge();
+            log.info("Audit log processing completed - processed: {}, skipped: {}", processedCount, skippedCount);
+            
+        } catch (Exception e) {
+            log.error("Error processing audit log events", e);
+            throw e; // 메시지가 재시도되거나 DLQ로 전송됩니다
+        }
+    }
+    
+    private void saveEventLog(ConsumerRecord<String, JsonNode> message, String eventId, 
+                             String eventType, JsonNode eventData, Long version) {
+        String aggregateId = null;
+        switch (message.topic()) {
+            case "catalog-events":
+                aggregateId = eventData.has("productId") ? eventData.get("productId").asText() : null;
+                break;
+            case "order-events":
+                aggregateId = eventData.has("orderId") ? eventData.get("orderId").asText() : null;
+                break;
+        }
+        
+        try {
+            EventLog eventLog = new EventLog(
+                eventId,
+                eventType,
+                message.topic(),
+                message.key(),
+                aggregateId,
+                objectMapper.writeValueAsString(eventData),
+                ZonedDateTime.now(),
+                version
+            );
+            
+            eventLogRepository.save(eventLog);
+            log.trace("Event log saved - eventId: {}, topic: {}, partition: {}", 
+                eventId, message.topic(), message.partition());
+        } catch (Exception e) {
+            log.error("Failed to save event log for eventId: {}", eventId, e);
+            throw new RuntimeException("Failed to save event log", e);
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/consumer/CacheInvalidationConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/consumer/CacheInvalidationConsumer.java
@@ -1,0 +1,217 @@
+package com.loopers.consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.loopers.config.kafka.KafkaConfig;
+import com.loopers.domain.event.EventHandled;
+import com.loopers.service.IdempotentEventService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 카탈로그 이벤트를 기반으로 한 캐시 무효화 컨슈머
+ * 제품 상태 변경(좋아요, 재고 등) 시 캐시된 데이터를 제거합니다
+ */
+@Component
+public class CacheInvalidationConsumer {
+    
+    private static final Logger log = LoggerFactory.getLogger(CacheInvalidationConsumer.class);
+    
+    private final IdempotentEventService idempotentEventService;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public CacheInvalidationConsumer(IdempotentEventService idempotentEventService,
+                                   RedisTemplate<String, Object> redisTemplate) {
+        this.idempotentEventService = idempotentEventService;
+        this.redisTemplate = redisTemplate;
+    }
+    
+    @KafkaListener(
+        topics = {"catalog-events"},  // 캐시 무효화를 위해 카탈로그 이벤트만 수신
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+        groupId = "cache-invalidation-consumer-group"
+    )
+    @Transactional
+    public void cacheInvalidationListener(List<ConsumerRecord<String, JsonNode>> messages,
+                                        Acknowledgment acknowledgment) {
+        log.info("Processing {} events for cache invalidation", messages.size());
+        
+        int processedCount = 0;
+        int skippedCount = 0;
+        
+        try {
+            for (ConsumerRecord<String, JsonNode> message : messages) {
+                JsonNode eventData = message.value();
+                String eventId = eventData.has("eventId") ? eventData.get("eventId").asText() : null;
+                String eventType = eventData.has("eventType") ? eventData.get("eventType").asText() : null;
+                Long version = eventData.has("version") ? eventData.get("version").asLong() : null;
+                
+                if (eventId == null || eventType == null) {
+                    log.warn("Skipping invalid event - missing eventId or eventType: {}", eventData);
+                    skippedCount++;
+                    continue;
+                }
+                
+                boolean processed = idempotentEventService.processEventIdempotent(
+                    eventId,
+                    EventHandled.ConsumerType.CACHE_INVALIDATION,
+                    version,
+                    () -> processCacheInvalidationEvent(eventData, eventType)
+                );
+                
+                if (processed) {
+                    processedCount++;
+                    log.debug("Processed cache invalidation for event: eventId={}, eventType={}", eventId, eventType);
+                } else {
+                    skippedCount++;
+                    log.debug("Skipped duplicate cache invalidation event: eventId={}, eventType={}", eventId, eventType);
+                }
+            }
+            
+            // 성공적인 처리 후 수동 확인응답
+            acknowledgment.acknowledge();
+            log.info("Cache invalidation completed - processed: {}, skipped: {}", processedCount, skippedCount);
+            
+        } catch (Exception e) {
+            log.error("Error processing cache invalidation events", e);
+            throw e; // 메시지가 재시도되거나 DLQ로 전송됩니다
+        }
+    }
+    
+    private void processCacheInvalidationEvent(JsonNode eventData, String eventType) {
+        Long productId = eventData.has("productId") ? eventData.get("productId").asLong() : null;
+        if (productId == null) {
+            log.warn("Skipping cache invalidation - missing productId in event: {}", eventData);
+            return;
+        }
+        
+        switch (eventType) {
+            case "PRODUCT_LIKED":
+            case "PRODUCT_UNLIKED":
+                // 제품 상세 캐시 무효화 (좋아요 수 변경됨)
+                invalidateProductCache(productId, "Product likes changed");
+                break;
+                
+            case "STOCK_ADJUSTED":
+                JsonNode stockData = eventData.get("eventData");
+                if (stockData != null && stockData.has("quantity")) {
+                    int quantity = stockData.get("quantity").asInt();
+                    // 재고가 0이 되거나 재고가 보충될 때 캐시 무효화
+                    if (quantity <= 0) {
+                        invalidateProductCache(productId, "Stock depleted");
+                        invalidateProductListCaches(); // 품절 시 제품이 목록에서 제외될 수 있음
+                    } else {
+                        invalidateProductCache(productId, "Stock replenished");
+                        invalidateProductListCaches(); // 제품이 목록에 다시 포함될 수 있음
+                    }
+                }
+                break;
+                
+            case "PRODUCT_VIEWED":
+                // 제품 조회의 경우, 일반적으로 캐시를 무효화하지 않습니다
+                // 이는 단순히 메트릭 추적용입니다
+                log.debug("Product {} viewed - no cache invalidation needed", productId);
+                break;
+                
+            default:
+                log.debug("No cache invalidation needed for event type: {}", eventType);
+                break;
+        }
+    }
+    
+    /**
+     * 제품별 캐시 무효화
+     */
+    private void invalidateProductCache(Long productId, String reason) {
+        try {
+            // 제품별 캐시 키 패턴
+            String productCachePattern = "*product:" + productId + "*";
+            Set<String> keysToDelete = redisTemplate.keys(productCachePattern);
+            
+            if (keysToDelete != null && !keysToDelete.isEmpty()) {
+                redisTemplate.delete(keysToDelete);
+                log.info("Invalidated {} cache keys for productId={} - reason: {}", 
+                    keysToDelete.size(), productId, reason);
+                log.debug("Deleted cache keys: {}", keysToDelete);
+            } else {
+                log.debug("No cache keys found for productId={} - pattern: {}", productId, productCachePattern);
+            }
+            
+            // 특정 캐시 항목도 무효화
+            invalidateSpecificProductCaches(productId);
+            
+        } catch (Exception e) {
+            log.error("Failed to invalidate cache for productId={}", productId, e);
+            throw e;
+        }
+    }
+    
+    /**
+     * 특정 제품 캐시 항목 무효화
+     */
+    private void invalidateSpecificProductCaches(Long productId) {
+        try {
+            // 제품에 대한 일반적인 캐시 키 패턴
+            String[] cacheKeys = {
+                "product:detail:" + productId,
+                "product:info:" + productId,
+                "product:stock:" + productId,
+                "product:likes:" + productId
+            };
+            
+            for (String cacheKey : cacheKeys) {
+                Boolean deleted = redisTemplate.delete(cacheKey);
+                if (Boolean.TRUE.equals(deleted)) {
+                    log.debug("Deleted specific cache key: {}", cacheKey);
+                }
+            }
+            
+        } catch (Exception e) {
+            log.warn("Failed to invalidate specific product caches for productId={}", productId, e);
+            // 이것은 중요하지 않으므로 여기서 예외를 발생시키지 않습니다
+        }
+    }
+    
+    /**
+     * 제품 목록 캐시 무효화 (재고 가용성 변경 시)
+     */
+    private void invalidateProductListCaches() {
+        try {
+            // 제품 목록 캐시 키 패턴
+            String listCachePattern = "*product:list*";
+            Set<String> keysToDelete = redisTemplate.keys(listCachePattern);
+            
+            if (keysToDelete != null && !keysToDelete.isEmpty()) {
+                redisTemplate.delete(keysToDelete);
+                log.info("Invalidated {} product list cache keys", keysToDelete.size());
+                log.debug("Deleted product list cache keys: {}", keysToDelete);
+            }
+            
+            // 일반적인 목록 캐시 항목도 무효화
+            String[] commonListKeys = {
+                "products:all",
+                "products:popular",
+                "products:featured",
+                "products:categories"
+            };
+            
+            for (String cacheKey : commonListKeys) {
+                Boolean deleted = redisTemplate.delete(cacheKey);
+                if (Boolean.TRUE.equals(deleted)) {
+                    log.debug("Deleted common list cache key: {}", cacheKey);
+                }
+            }
+            
+        } catch (Exception e) {
+            log.warn("Failed to invalidate product list caches", e);
+            // 이것은 중요하지 않으므로 여기서 예외를 발생시키지 않습니다
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/consumer/MetricsAggregationConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/consumer/MetricsAggregationConsumer.java
@@ -1,0 +1,173 @@
+package com.loopers.consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.loopers.config.kafka.KafkaConfig;
+import com.loopers.domain.event.EventHandled;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.repository.ProductMetricsRepository;
+import com.loopers.service.IdempotentEventService;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 제품의 일일 메트릭 집계를 위한 컨슈머
+ * 좋아요, 판매, 조회 이벤트를 처리하여 일일 통계를 업데이트합니다
+ */
+@Component
+public class MetricsAggregationConsumer {
+    
+    private static final Logger log = LoggerFactory.getLogger(MetricsAggregationConsumer.class);
+    
+    private final ProductMetricsRepository productMetricsRepository;
+    private final IdempotentEventService idempotentEventService;
+
+    public MetricsAggregationConsumer(ProductMetricsRepository productMetricsRepository,
+                                     IdempotentEventService idempotentEventService) {
+        this.productMetricsRepository = productMetricsRepository;
+        this.idempotentEventService = idempotentEventService;
+    }
+    
+    @KafkaListener(
+        topics = {"catalog-events", "order-events"},
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+        groupId = "metrics-aggregation-consumer-group"
+    )
+    @Transactional
+    public void metricsAggregationListener(List<ConsumerRecord<String, JsonNode>> messages,
+                                          Acknowledgment acknowledgment) {
+        log.info("Processing {} events for metrics aggregation", messages.size());
+        
+        int processedCount = 0;
+        int skippedCount = 0;
+        
+        try {
+            for (ConsumerRecord<String, JsonNode> message : messages) {
+                JsonNode eventData = message.value();
+                String eventId = eventData.has("eventId") ? eventData.get("eventId").asText() : null;
+                String eventType = eventData.has("eventType") ? eventData.get("eventType").asText() : null;
+                Long version = eventData.has("version") ? eventData.get("version").asLong() : null;
+                
+                if (eventId == null || eventType == null) {
+                    log.warn("Skipping invalid event - missing eventId or eventType: {}", eventData);
+                    skippedCount++;
+                    continue;
+                }
+                
+                boolean processed = idempotentEventService.processEventIdempotent(
+                    eventId,
+                    EventHandled.ConsumerType.METRICS_AGGREGATION,
+                    version,
+                    () -> processMetricsEvent(eventData, eventType)
+                );
+                
+                if (processed) {
+                    processedCount++;
+                    log.debug("Processed metrics for event: eventId={}, eventType={}", eventId, eventType);
+                } else {
+                    skippedCount++;
+                    log.debug("Skipped duplicate metrics event: eventId={}, eventType={}", eventId, eventType);
+                }
+            }
+            
+            // 성공적인 처리 후 수동 확인응답
+            acknowledgment.acknowledge();
+            log.info("Metrics aggregation completed - processed: {}, skipped: {}", processedCount, skippedCount);
+            
+        } catch (Exception e) {
+            log.error("Error processing metrics aggregation events", e);
+            throw e; // 메시지가 재시도되거나 DLQ로 전송됩니다
+        }
+    }
+    
+    private void processMetricsEvent(JsonNode eventData, String eventType) {
+        switch (eventType) {
+            case "PRODUCT_LIKED":
+                Long productIdLiked = eventData.has("productId") ? eventData.get("productId").asLong() : null;
+                if (productIdLiked != null) {
+                    updateProductMetrics(productIdLiked, 1L, 0L, 0L);
+                }
+                break;
+                
+            case "PRODUCT_UNLIKED":
+                Long productIdUnliked = eventData.has("productId") ? eventData.get("productId").asLong() : null;
+                if (productIdUnliked != null) {
+                    updateProductMetrics(productIdUnliked, -1L, 0L, 0L);
+                }
+                break;
+                
+            case "PRODUCT_VIEWED":
+                Long productIdViewed = eventData.has("productId") ? eventData.get("productId").asLong() : null;
+                if (productIdViewed != null) {
+                    updateProductMetrics(productIdViewed, 0L, 0L, 1L);
+                }
+                break;
+                
+            case "ORDER_CREATED":
+                JsonNode orderEventData = eventData.get("eventData");
+                if (orderEventData != null && orderEventData.has("items")) {
+                    JsonNode items = orderEventData.get("items");
+                    if (items.isArray()) {
+                        for (JsonNode item : items) {
+                            Long productId = item.has("productId") ? item.get("productId").asLong() : null;
+                            Long quantity = item.has("quantity") ? item.get("quantity").asLong() : 1L;
+                            if (productId != null) {
+                                updateProductMetrics(productId, 0L, quantity, 0L);
+                            }
+                        }
+                    }
+                }
+                break;
+                
+            default:
+                log.debug("Ignoring event type for metrics: {}", eventType);
+                break;
+        }
+    }
+    
+    private void updateProductMetrics(Long productId, Long likesChange, Long salesChange, Long viewsChange) {
+        LocalDate today = LocalDate.now();
+        
+        try {
+            // 오늘에 대한 기존 메트릭 찾기 시도
+            ProductMetrics existingMetrics = productMetricsRepository.findByProductIdAndMetricDate(productId, today);
+            
+            if (existingMetrics != null) {
+                // 기존 메트릭 업데이트
+                existingMetrics.updateLikes(likesChange);
+                existingMetrics.updateSales(salesChange);
+                existingMetrics.updateViews(viewsChange);
+                productMetricsRepository.save(existingMetrics);
+                
+                log.debug("Updated metrics for productId={}, likesChange={}, salesChange={}, viewsChange={}", 
+                    productId, likesChange, salesChange, viewsChange);
+            } else {
+                // 새로운 메트릭 항목 생성
+                ProductMetrics newMetrics = new ProductMetrics(
+                    productId,
+                    today,
+                    Math.max(0L, likesChange),
+                    likesChange,
+                    Math.max(0L, salesChange),
+                    salesChange,
+                    Math.max(0L, viewsChange),
+                    viewsChange
+                );
+                productMetricsRepository.save(newMetrics);
+                
+                log.debug("Created new metrics for productId={}, likesChange={}, salesChange={}, viewsChange={}", 
+                    productId, likesChange, salesChange, viewsChange);
+            }
+            
+        } catch (Exception e) {
+            log.error("Error updating metrics for productId={}", productId, e);
+            throw e;
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/BaseEntity.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/BaseEntity.java
@@ -1,0 +1,69 @@
+package com.loopers.domain;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // Getter와 Setter 메서드들
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void markAsDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventHandled.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventHandled.java
@@ -1,0 +1,85 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import java.time.ZonedDateTime;
+
+/**
+ * 멱등성 처리를 위한 이벤트 처리 추적 테이블
+ * 동일한 이벤트의 중복 처리를 방지합니다
+ */
+@Entity
+@Table(
+    name = "event_handled",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"event_id", "consumer_type"})
+    }
+)
+public class EventHandled extends BaseEntity {
+
+    @Column(name = "event_id", nullable = false)
+    private String eventId;
+
+    @Column(name = "consumer_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ConsumerType consumerType;
+
+    @Column(name = "handled_at", nullable = false)
+    private ZonedDateTime handledAt;
+
+    @Column(name = "version")
+    private Long version;
+
+    // 기본 생성자
+    public EventHandled() {
+        this("", ConsumerType.AUDIT_LOG, ZonedDateTime.now(), null);
+    }
+
+    // 전체 생성자
+    public EventHandled(String eventId, ConsumerType consumerType, ZonedDateTime handledAt, Long version) {
+        this.eventId = eventId;
+        this.consumerType = consumerType;
+        this.handledAt = handledAt;
+        this.version = version;
+    }
+
+    // 컴슈머 타입을 위한 Enum
+    public enum ConsumerType {
+        AUDIT_LOG,
+        METRICS_AGGREGATION,
+        CACHE_INVALIDATION
+    }
+
+    // Getter와 Setter 메서드들
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public ConsumerType getConsumerType() {
+        return consumerType;
+    }
+
+    public void setConsumerType(ConsumerType consumerType) {
+        this.consumerType = consumerType;
+    }
+
+    public ZonedDateTime getHandledAt() {
+        return handledAt;
+    }
+
+    public void setHandledAt(ZonedDateTime handledAt) {
+        this.handledAt = handledAt;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventLog.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/event/EventLog.java
@@ -1,0 +1,121 @@
+package com.loopers.domain.event;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import java.time.ZonedDateTime;
+
+/**
+ * 감사 목적의 이벤트 로그 테이블
+ * 컨슈머에 의해 처리된 모든 이벤트를 저장합니다
+ */
+@Entity
+@Table(name = "event_log")
+public class EventLog extends BaseEntity {
+    
+    @Column(name = "event_id", nullable = false, unique = true)
+    private String eventId;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(name = "topic", nullable = false)
+    private String topic;
+
+    @Column(name = "partition_key")
+    private String partitionKey;
+
+    @Column(name = "aggregate_id")
+    private String aggregateId;
+
+    @Column(name = "event_data", columnDefinition = "TEXT")
+    private String eventData;
+
+    @Column(name = "processed_at", nullable = false)
+    private ZonedDateTime processedAt;
+
+    @Column(name = "version")
+    private Long version;
+
+    // 기본 생성자
+    public EventLog() {
+        this("", "", "", null, null, "", ZonedDateTime.now(), null);
+    }
+
+    // 전체 생성자
+    public EventLog(String eventId, String eventType, String topic, String partitionKey, 
+                   String aggregateId, String eventData, ZonedDateTime processedAt, Long version) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.topic = topic;
+        this.partitionKey = partitionKey;
+        this.aggregateId = aggregateId;
+        this.eventData = eventData;
+        this.processedAt = processedAt;
+        this.version = version;
+    }
+
+    // Getter와 Setter 메서드들
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getPartitionKey() {
+        return partitionKey;
+    }
+
+    public void setPartitionKey(String partitionKey) {
+        this.partitionKey = partitionKey;
+    }
+
+    public String getAggregateId() {
+        return aggregateId;
+    }
+
+    public void setAggregateId(String aggregateId) {
+        this.aggregateId = aggregateId;
+    }
+
+    public String getEventData() {
+        return eventData;
+    }
+
+    public void setEventData(String eventData) {
+        this.eventData = eventData;
+    }
+
+    public ZonedDateTime getProcessedAt() {
+        return processedAt;
+    }
+
+    public void setProcessedAt(ZonedDateTime processedAt) {
+        this.processedAt = processedAt;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,0 +1,150 @@
+package com.loopers.domain.metrics;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+/**
+ * 일일 제품 메트릭 집계 테이블
+ * 좋아요, 판매, 조회에 대한 일일 통계를 저장합니다
+ */
+@Entity
+@Table(
+    name = "product_metrics",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"product_id", "metric_date"})
+    }
+)
+public class ProductMetrics extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "metric_date", nullable = false)
+    private LocalDate metricDate;
+
+    @Column(name = "likes_count", nullable = false)
+    private Long likesCount = 0L;
+
+    @Column(name = "likes_change", nullable = false)
+    private Long likesChange = 0L;
+
+    @Column(name = "sales_count", nullable = false)
+    private Long salesCount = 0L;
+
+    @Column(name = "sales_change", nullable = false)
+    private Long salesChange = 0L;
+
+    @Column(name = "views_count", nullable = false)
+    private Long viewsCount = 0L;
+
+    @Column(name = "views_change", nullable = false)
+    private Long viewsChange = 0L;
+
+    // 기본 생성자
+    public ProductMetrics() {
+        this(0L, LocalDate.now(), 0L, 0L, 0L, 0L, 0L, 0L);
+    }
+
+    // 전체 생성자
+    public ProductMetrics(Long productId, LocalDate metricDate, Long likesCount, Long likesChange,
+                         Long salesCount, Long salesChange, Long viewsCount, Long viewsChange) {
+        this.productId = productId;
+        this.metricDate = metricDate;
+        this.likesCount = likesCount;
+        this.likesChange = likesChange;
+        this.salesCount = salesCount;
+        this.salesChange = salesChange;
+        this.viewsCount = viewsCount;
+        this.viewsChange = viewsChange;
+    }
+
+    /**
+     * 좋아요 메트릭 업데이트
+     */
+    public void updateLikes(Long change) {
+        this.likesChange += change;
+        this.likesCount = Math.max(0L, this.likesCount + change);
+    }
+
+    /**
+     * 판매 메트릭 업데이트
+     */
+    public void updateSales(Long change) {
+        this.salesChange += change;
+        this.salesCount += change;
+    }
+
+    /**
+     * 조회 메트릭 업데이트
+     */
+    public void updateViews(Long change) {
+        this.viewsChange += change;
+        this.viewsCount += change;
+    }
+
+    // Getter와 Setter 메서드들
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public LocalDate getMetricDate() {
+        return metricDate;
+    }
+
+    public void setMetricDate(LocalDate metricDate) {
+        this.metricDate = metricDate;
+    }
+
+    public Long getLikesCount() {
+        return likesCount;
+    }
+
+    public void setLikesCount(Long likesCount) {
+        this.likesCount = likesCount;
+    }
+
+    public Long getLikesChange() {
+        return likesChange;
+    }
+
+    public void setLikesChange(Long likesChange) {
+        this.likesChange = likesChange;
+    }
+
+    public Long getSalesCount() {
+        return salesCount;
+    }
+
+    public void setSalesCount(Long salesCount) {
+        this.salesCount = salesCount;
+    }
+
+    public Long getSalesChange() {
+        return salesChange;
+    }
+
+    public void setSalesChange(Long salesChange) {
+        this.salesChange = salesChange;
+    }
+
+    public Long getViewsCount() {
+        return viewsCount;
+    }
+
+    public void setViewsCount(Long viewsCount) {
+        this.viewsCount = viewsCount;
+    }
+
+    public Long getViewsChange() {
+        return viewsChange;
+    }
+
+    public void setViewsChange(Long viewsChange) {
+        this.viewsChange = viewsChange;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/EventMonitoringController.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/EventMonitoringController.java
@@ -1,0 +1,117 @@
+package com.loopers.interfaces;
+
+import com.loopers.domain.event.EventLog;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.service.EventTestService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 이벤트 처리 모니터링을 위한 REST 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/events")
+public class EventMonitoringController {
+    
+    private final EventTestService eventTestService;
+
+    public EventMonitoringController(EventTestService eventTestService) {
+        this.eventTestService = eventTestService;
+    }
+
+    /**
+     * 이벤트 처리 통계 조회
+     */
+    @GetMapping("/stats")
+    public ResponseEntity<EventTestService.EventProcessingStats> getProcessingStats() {
+        EventTestService.EventProcessingStats stats = eventTestService.getProcessingStats();
+        return ResponseEntity.ok(stats);
+    }
+    
+    /**
+     * 특정 이벤트가 처리되었는지 확인
+     */
+    @GetMapping("/verify/{eventId}")
+    public ResponseEntity<EventVerificationResponse> verifyEventProcessing(@PathVariable String eventId) {
+        boolean processed = eventTestService.verifyEventProcessing(eventId);
+        EventVerificationResponse response = new EventVerificationResponse();
+        response.setEventId(eventId);
+        response.setProcessed(processed);
+        return ResponseEntity.ok(response);
+    }
+    
+    /**
+     * 특정 날짜의 제품 메트릭 조회
+     */
+    @GetMapping("/metrics/product/{productId}")
+    public ResponseEntity<ProductMetrics> getProductMetrics(
+            @PathVariable Long productId,
+            @RequestParam(required = false) 
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        
+        LocalDate queryDate = date != null ? date : LocalDate.now();
+        ProductMetrics metrics = eventTestService.getProductMetrics(productId, queryDate);
+        
+        if (metrics != null) {
+            return ResponseEntity.ok(metrics);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+    
+    /**
+     * 제품에 대한 Redis 캐시 키 조회
+     */
+    @GetMapping("/cache/product/{productId}")
+    public ResponseEntity<Set<String>> getProductCacheKeys(@PathVariable Long productId) {
+        Set<String> cacheKeys = eventTestService.getProductCacheKeys(productId);
+        return ResponseEntity.ok(cacheKeys);
+    }
+    
+    /**
+     * 감사 로그에서 최근 이벤트 조회
+     */
+    @GetMapping("/recent")
+    public ResponseEntity<List<EventLog>> getRecentEvents(
+            @RequestParam(defaultValue = "10") int limit) {
+        List<EventLog> recentEvents = eventTestService.getRecentEvents(limit);
+        return ResponseEntity.ok(recentEvents);
+    }
+    
+    /**
+     * 헬스 체크 엔드포인트
+     */
+    @GetMapping("/health")
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("Event processing system is healthy");
+    }
+    
+    /**
+     * 이벤트 검증을 위한 응답 클래스
+     */
+    public static class EventVerificationResponse {
+        private String eventId;
+        private boolean processed;
+        
+        // Getter와 Setter 메서드들
+        public String getEventId() {
+            return eventId;
+        }
+        
+        public void setEventId(String eventId) {
+            this.eventId = eventId;
+        }
+        
+        public boolean isProcessed() {
+            return processed;
+        }
+        
+        public void setProcessed(boolean processed) {
+            this.processed = processed;
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/repository/EventHandledRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/repository/EventHandledRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.repository;
+
+import com.loopers.domain.event.EventHandled;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventHandledRepository extends JpaRepository<EventHandled, Long> {
+    boolean existsByEventIdAndConsumerType(String eventId, EventHandled.ConsumerType consumerType);
+    
+    EventHandled findByEventIdAndConsumerType(String eventId, EventHandled.ConsumerType consumerType);
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/repository/EventLogRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/repository/EventLogRepository.java
@@ -1,0 +1,18 @@
+package com.loopers.repository;
+
+import com.loopers.domain.event.EventLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public interface EventLogRepository extends JpaRepository<EventLog, Long> {
+    boolean existsByEventId(String eventId);
+    
+    EventLog findByEventIdAndEventType(String eventId, String eventType);
+    
+    List<EventLog> findByEventTypeAndProcessedAtBetween(
+        String eventType,
+        ZonedDateTime startTime,
+        ZonedDateTime endTime
+    );
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/repository/ProductMetricsRepository.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/repository/ProductMetricsRepository.java
@@ -1,0 +1,43 @@
+package com.loopers.repository;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ProductMetricsRepository extends JpaRepository<ProductMetrics, Long> {
+    ProductMetrics findByProductIdAndMetricDate(Long productId, LocalDate metricDate);
+    
+    @Modifying
+    @Query(value = """
+        INSERT INTO product_metrics (product_id, metric_date, likes_count, likes_change, sales_count, sales_change, views_count, views_change, created_at, updated_at)
+        VALUES (:productId, :metricDate, :likesCount, :likesChange, :salesCount, :salesChange, :viewsCount, :viewsChange, NOW(), NOW())
+        ON DUPLICATE KEY UPDATE
+        likes_count = likes_count + VALUES(likes_change),
+        likes_change = likes_change + VALUES(likes_change),
+        sales_count = sales_count + VALUES(sales_change),
+        sales_change = sales_change + VALUES(sales_change),
+        views_count = views_count + VALUES(views_change),
+        views_change = views_change + VALUES(views_change),
+        updated_at = NOW()
+    """, nativeQuery = true)
+    void upsertMetrics(
+        @Param("productId") Long productId,
+        @Param("metricDate") LocalDate metricDate,
+        @Param("likesCount") Long likesCount,
+        @Param("likesChange") Long likesChange,
+        @Param("salesCount") Long salesCount,
+        @Param("salesChange") Long salesChange,
+        @Param("viewsCount") Long viewsCount,
+        @Param("viewsChange") Long viewsChange
+    );
+    
+    List<ProductMetrics> findByProductIdAndMetricDateBetween(
+        Long productId,
+        LocalDate startDate,
+        LocalDate endDate
+    );
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/service/EventTestService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/service/EventTestService.java
@@ -1,0 +1,114 @@
+package com.loopers.service;
+
+import com.loopers.domain.event.EventLog;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.repository.EventLogRepository;
+import com.loopers.repository.ProductMetricsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 이벤트 파이프라인 테스트 및 모니터링을 위한 서비스
+ */
+@Service
+public class EventTestService {
+    
+    private static final Logger log = LoggerFactory.getLogger(EventTestService.class);
+    
+    private final EventLogRepository eventLogRepository;
+    private final ProductMetricsRepository productMetricsRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public EventTestService(EventLogRepository eventLogRepository,
+                           ProductMetricsRepository productMetricsRepository,
+                           RedisTemplate<String, Object> redisTemplate) {
+        this.eventLogRepository = eventLogRepository;
+        this.productMetricsRepository = productMetricsRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 모든 컴슈머에 의해 이벤트가 처리되었는지 확인
+     */
+    public boolean verifyEventProcessing(String eventId) {
+        log.info("Verifying event processing for eventId: {}", eventId);
+        
+        // 이벤트가 감사 로그에 기록되었는지 확인
+        boolean auditLogged = eventLogRepository.existsByEventId(eventId);
+        log.info("Event {} audit logged: {}", eventId, auditLogged);
+        
+        return auditLogged;
+    }
+    
+    /**
+     * 이벤트 처리 통계 조회
+     */
+    public EventProcessingStats getProcessingStats() {
+        long totalEvents = eventLogRepository.count();
+        long totalMetrics = productMetricsRepository.count();
+        
+        EventProcessingStats stats = new EventProcessingStats();
+        stats.setTotalEventsProcessed(totalEvents);
+        stats.setTotalMetricsRecords(totalMetrics);
+        
+        log.info("Event processing stats - Events: {}, Metrics: {}", totalEvents, totalMetrics);
+        
+        return stats;
+    }
+    
+    /**
+     * 특정 제품과 날짜에 대한 메트릭 조회
+     */
+    public ProductMetrics getProductMetrics(Long productId, LocalDate date) {
+        return productMetricsRepository.findByProductIdAndMetricDate(productId, date);
+    }
+    
+    /**
+     * 제품에 대한 Redis 캐시 키 확인
+     */
+    public Set<String> getProductCacheKeys(Long productId) {
+        String pattern = "*product:" + productId + "*";
+        return redisTemplate.keys(pattern);
+    }
+    
+    /**
+     * 감사 로그에서 최근 이벤트 조회
+     */
+    public List<EventLog> getRecentEvents(int limit) {
+        List<EventLog> allEvents = eventLogRepository.findAll();
+        return allEvents.stream()
+                .sorted((a, b) -> b.getProcessedAt().compareTo(a.getProcessedAt()))
+                .limit(limit)
+                .toList();
+    }
+    
+    /**
+     * 이벤트 처리를 위한 통계 클래스
+     */
+    public static class EventProcessingStats {
+        private long totalEventsProcessed;
+        private long totalMetricsRecords;
+        
+        // Getter와 Setter 메서드들
+        public long getTotalEventsProcessed() {
+            return totalEventsProcessed;
+        }
+        
+        public void setTotalEventsProcessed(long totalEventsProcessed) {
+            this.totalEventsProcessed = totalEventsProcessed;
+        }
+        
+        public long getTotalMetricsRecords() {
+            return totalMetricsRecords;
+        }
+        
+        public void setTotalMetricsRecords(long totalMetricsRecords) {
+            this.totalMetricsRecords = totalMetricsRecords;
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/service/IdempotentEventService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/service/IdempotentEventService.java
@@ -1,0 +1,81 @@
+package com.loopers.service;
+
+import com.loopers.domain.event.EventHandled;
+import com.loopers.repository.EventHandledRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.ZonedDateTime;
+
+/**
+ * 멱등성 이벤트 처리를 담당하는 서비스
+ */
+@Service
+public class IdempotentEventService {
+    
+    private static final Logger log = LoggerFactory.getLogger(IdempotentEventService.class);
+    
+    private final EventHandledRepository eventHandledRepository;
+
+    public IdempotentEventService(EventHandledRepository eventHandledRepository) {
+        this.eventHandledRepository = eventHandledRepository;
+    }
+
+    /**
+     * 해당 컨슈머 타입에서 이벤트가 이미 처리되었는지 확인
+     */
+    @Transactional(readOnly = true)
+    public boolean isEventAlreadyHandled(String eventId, EventHandled.ConsumerType consumerType) {
+        return eventHandledRepository.existsByEventIdAndConsumerType(eventId, consumerType);
+    }
+
+    /**
+     * 해당 컨슈머 타입에서 이벤트를 처리됨으로 표시
+     * 성공적으로 표시되면 true 반환 (첫 번째 처리)
+     * 이미 표시되어 있으면 false 반환 (중복 처리 시도)
+     */
+    @Transactional
+    public boolean markEventAsHandled(String eventId, EventHandled.ConsumerType consumerType, Long version) {
+        if (isEventAlreadyHandled(eventId, consumerType)) {
+            log.warn("Event {} already handled by consumer {}", eventId, consumerType);
+            return false;
+        }
+
+        try {
+            EventHandled eventHandled = new EventHandled(
+                eventId,
+                consumerType,
+                ZonedDateTime.now(),
+                version
+            );
+            eventHandledRepository.save(eventHandled);
+            log.debug("Event {} marked as handled by consumer {}", eventId, consumerType);
+            return true;
+        } catch (Exception e) {
+            // 다른 스레드가 같은 레코드를 삽입했을 수 있는 경합 상황 처리
+            log.warn("Failed to mark event {} as handled by consumer {}: {}", eventId, consumerType, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 멱등성을 보장하며 이벤트 처리
+     * 이벤트가 처리되면 true, 이미 처리된 경우 false 반환
+     */
+    @Transactional
+    public boolean processEventIdempotent(String eventId, EventHandled.ConsumerType consumerType, 
+                                        Long version, Runnable processor) {
+        if (!markEventAsHandled(eventId, consumerType, version)) {
+            return false;  // 이미 처리됨
+        }
+
+        try {
+            processor.run();
+            return true;
+        } catch (Exception e) {
+            log.error("Error processing event {} for consumer {}", eventId, consumerType, e);
+            throw e;
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
@@ -1,0 +1,22 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+class CommerceStreamerApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<CommerceStreamerApplication>(*args)
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/CommerceStreamerApplication.kt
@@ -4,15 +4,19 @@ import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import java.util.TimeZone
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableJpaRepositories(basePackages = ["com.loopers.repository"])
+@EnableJpaAuditing
 class CommerceStreamerApplication {
 
     @PostConstruct
     fun started() {
-        // set timezone
+        // 타임존 설정
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
     }
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/DemoKafkaConsumer.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/interfaces/consumer/DemoKafkaConsumer.kt
@@ -1,0 +1,22 @@
+package com.loopers.interfaces.consumer
+
+import com.loopers.config.kafka.KafkaConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Component
+
+@Component
+class DemoKafkaConsumer {
+    @KafkaListener(
+        topics = ["\${demo-kafka.test.topic-name}"],
+        containerFactory = KafkaConfig.BATCH_LISTENER,
+    )
+    fun demoListener(
+        messages: List<ConsumerRecord<Any, Any>>,
+        acknowledgment: Acknowledgment,
+    ) {
+        println(messages)
+        acknowledgment.acknowledge() // manual ack
+    }
+}

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -1,0 +1,58 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - kafka.yml
+      - logging.yml
+      - monitoring.yml
+
+demo-kafka:
+  test:
+    topic-name: demo.internal.topic-v1
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-streamer/src/main/resources/application.yml
+++ b/apps/commerce-streamer/src/main/resources/application.yml
@@ -1,29 +1,39 @@
 server:
+  port: 8082
   shutdown: graceful
   tomcat:
     threads:
-      max: 200 # 최대 워커 스레드 수 (default : 200)
-      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
-    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
-    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
-    accept-count: 100 # 대기 큐 크기 (default : 100)
-    keep-alive-timeout: 60s # 60s
+      max: 200 # 최대 워커 스레드 수 (기본값: 200)
+      min-spare: 10 # 최소 유지 스레드 수 (기본값: 10)
+    connection-timeout: 1m # 연결 타임아웃 (기본값: 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (기본값: 8192)
+    accept-count: 100 # 대기 큐 크기 (기본값: 100)
+    keep-alive-timeout: 60s # 연결 유지 시간: 60초
   max-http-request-header-size: 8KB
 
 spring:
   main:
     web-application-type: servlet
   application:
-    name: commerce-api
+    name: commerce-streamer
   profiles:
     active: local
   config:
     import:
       - jpa.yml
-      - redis.yml
       - kafka.yml
       - logging.yml
-      - monitoring.yml
+  # Redis 설정
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
 
 demo-kafka:
   test:
@@ -56,3 +66,7 @@ spring:
 springdoc:
   api-docs:
     enabled: false
+
+management:
+  endpoints:
+    enabled-by-default: false

--- a/apps/commerce-streamer/src/test/java/com/loopers/EventPipelineIntegrationTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/EventPipelineIntegrationTest.java
@@ -1,0 +1,187 @@
+package com.loopers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.event.EventLog;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.repository.EventLogRepository;
+import com.loopers.repository.ProductMetricsRepository;
+import com.loopers.service.EventTestService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 완전한 Kafka 이벤트 파이프라인에 대한 통합 테스트
+ */
+@SpringBootTest
+@EmbeddedKafka(
+    partitions = 1,
+    topics = {"catalog-events", "order-events"},
+    brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"}
+)
+@TestPropertySource(properties = {
+    "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+    "spring.kafka.consumer.auto-offset-reset=earliest"
+})
+@Transactional
+class EventPipelineIntegrationTest {
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+    
+    @Autowired
+    private EventLogRepository eventLogRepository;
+    
+    @Autowired
+    private ProductMetricsRepository productMetricsRepository;
+    
+    @Autowired
+    private EventTestService eventTestService;
+    
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+    
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testProductLikeEventPipeline() throws Exception {
+        // Given - 제품 좋아요 이벤트 생성
+        String eventId = UUID.randomUUID().toString();
+        Long productId = 123L;
+        String userId = "user456";
+        
+        Map<String, Object> catalogEvent = createCatalogEvent(eventId, "PRODUCT_LIKED", productId, userId);
+        
+        // When - Kafka로 이벤트 전송
+        kafkaTemplate.send("catalog-events", String.valueOf(productId), catalogEvent);
+        
+        // Then - Wait for event to be processed by all consumers
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            // 감사 로그 검증
+            assertTrue(eventLogRepository.existsByEventId(eventId), 
+                "Event should be logged in audit log");
+            
+            // 메트릭이 업데이트되었는지 검증
+            ProductMetrics metrics = productMetricsRepository.findByProductIdAndMetricDate(
+                productId, LocalDate.now());
+            assertNotNull(metrics, "Product metrics should be created");
+            assertEquals(1L, metrics.getLikesChange(), "Likes change should be 1");
+        });
+        
+        // Verify event test service
+        assertTrue(eventTestService.verifyEventProcessing(eventId),
+            "Event should be verified as processed");
+    }
+    
+    @Test
+    void testProductUnlikeEventPipeline() throws Exception {
+        // Given - Create a product unlike event
+        String eventId = UUID.randomUUID().toString();
+        Long productId = 124L;
+        String userId = "user789";
+        
+        Map<String, Object> catalogEvent = createCatalogEvent(eventId, "PRODUCT_UNLIKED", productId, userId);
+        
+        // When - Kafka로 이벤트 전송
+        kafkaTemplate.send("catalog-events", String.valueOf(productId), catalogEvent);
+        
+        // Then - Wait for event to be processed
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            // 감사 로그 검증
+            EventLog eventLog = eventLogRepository.findByEventIdAndEventType(eventId, "PRODUCT_UNLIKED");
+            assertNotNull(eventLog, "Event should be in audit log");
+            assertEquals("catalog-events", eventLog.getTopic(), "Topic should be catalog-events");
+            
+            // 메트릭이 업데이트되었는지 검증 (unlike decreases likes)
+            ProductMetrics metrics = productMetricsRepository.findByProductIdAndMetricDate(
+                productId, LocalDate.now());
+            assertNotNull(metrics, "Product metrics should be created");
+            assertEquals(-1L, metrics.getLikesChange(), "Likes change should be -1");
+        });
+    }
+    
+    @Test
+    void testDuplicateEventIdempotency() throws Exception {
+        // Given - Create an event
+        String eventId = UUID.randomUUID().toString();
+        Long productId = 125L;
+        String userId = "user999";
+        
+        Map<String, Object> catalogEvent = createCatalogEvent(eventId, "PRODUCT_LIKED", productId, userId);
+        
+        // When - Send the same event twice
+        kafkaTemplate.send("catalog-events", String.valueOf(productId), catalogEvent);
+        kafkaTemplate.send("catalog-events", String.valueOf(productId), catalogEvent);
+        
+        // Then - Wait and verify only processed once
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            // Should only have one audit log entry
+            long auditCount = eventLogRepository.findAll().stream()
+                .filter(log -> eventId.equals(log.getEventId()))
+                .count();
+            assertEquals(1L, auditCount, "Should only have one audit log entry");
+            
+            // Should only have one metrics update
+            ProductMetrics metrics = productMetricsRepository.findByProductIdAndMetricDate(
+                productId, LocalDate.now());
+            assertNotNull(metrics, "Product metrics should be created");
+            assertEquals(1L, metrics.getLikesChange(), "Should only process once - likes change should be 1");
+        });
+    }
+    
+    @Test
+    void testEventProcessingStats() {
+        // Given - Some initial state
+        EventTestService.EventProcessingStats initialStats = eventTestService.getProcessingStats();
+        
+        // When - Send an event
+        String eventId = UUID.randomUUID().toString();
+        Long productId = 126L;
+        String userId = "user111";
+        
+        Map<String, Object> catalogEvent = createCatalogEvent(eventId, "PRODUCT_VIEWED", productId, userId);
+        kafkaTemplate.send("catalog-events", String.valueOf(productId), catalogEvent);
+        
+        // Then - Stats should be updated
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            EventTestService.EventProcessingStats currentStats = eventTestService.getProcessingStats();
+            assertTrue(currentStats.getTotalEventsProcessed() > initialStats.getTotalEventsProcessed(),
+                "Total events processed should increase");
+        });
+    }
+    
+    private Map<String, Object> createCatalogEvent(String eventId, String eventType, Long productId, String userId) {
+        Map<String, Object> event = new HashMap<>();
+        event.put("eventId", eventId);
+        event.put("eventType", eventType);
+        event.put("productId", productId);
+        event.put("userId", userId);
+        event.put("timestamp", java.time.ZonedDateTime.now().toString());
+        event.put("version", System.currentTimeMillis());
+        
+        // 타입에 따른 이벤트 데이터
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("productId", productId);
+        eventData.put("userId", userId);
+        eventData.put("action", eventType.equals("PRODUCT_LIKED") ? "LIKED" : 
+                               eventType.equals("PRODUCT_UNLIKED") ? "UNLIKED" : "VIEWED");
+        event.put("eventData", eventData);
+        
+        return event;
+    }
+}

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -14,17 +14,97 @@ services:
     volumes:
       - mysql-8-data:/var/lib/mysql
 
-  redis:
-    image: redis:7-alpine
+  redis-master:
+    image: redis:7.0
+    container_name: redis-master
     ports:
       - "6379:6379"
-    command: redis-server --appendonly yes
     volumes:
-      - redis-data:/data
+      - redis_master_data:/data
+    command:
+      [
+        "redis-server", # redis 서버 실행 명령어
+        "--appendonly", "yes", # AOF (AppendOnlyFile) 영속성 기능 켜기
+        "--save", "",
+        "--latency-monitor-threshold", "100", # 특정 command 가 지정 시간(ms) 이상 걸리면 monitor 기록
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  redis-readonly:
+    image: redis:7.0
+    container_name: redis-readonly
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis_readonly_data:/data
+    command:
+      [
+        "redis-server",
+        "--appendonly", "yes",
+        "--appendfsync", "everysec",
+        "--replicaof", "redis-master", "6379", # replica 모드로 실행 + 서비스 명, 서비스 포트
+        "--replica-read-only", "yes", # 읽기 전용으로 설정
+        "--latency-monitor-threshold", "100",
+      ]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  kafka:
+    image: bitnami/kafka:3.5.1
+    container_name: kafka
+    ports:
+      - "9092:9092" # 카프카 브로커 PORT
+      - "19092:19092" # 호스트 리스너 얘 떄문인가
+    environment:
+      - KAFKA_CFG_NODE_ID=1 # 브로커 고유 ID
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller # KRaft 모드여서, broker / controller 역할 모두 부여
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:19092,CONTROLLER://:9093
+      # 브로커 클라이언트 (PLAINTEXT), 브로커 호스트 (PLAINTEXT) 내부 컨트롤러 (CONTROLLER)
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:19092
+      # 외부 클라이언트 접속 호스트 (localhost:9092), 브로커 접속 호스트 (localhost:19092)
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      # 각 리스너별 보안 프로토콜 설정
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER # 컨트롤러 담당 리스너 지정
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093 # 컨트롤러 후보 노드 정의 (단일 브로커라 자기 자신만 있음)
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1 # consumer offset 복제 갯수 (현재는 1 - 로컬용이라서)
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 # transaction log 토픽 복제 갯수 (현재는 1 - 로컬용이라서)
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1 # In-Sync-Replica 최소 수 (현재는 1 - 로컬용이라서)
+    volumes:
+      - kafka-data:/bitnami/kafka
+    healthcheck:
+      test: ["CMD", "bash", "-c", "kafka-topics.sh --bootstrap-server localhost:9092 --list || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "9090:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local  # kafka-ui 에서 보이는 클러스터명
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092 # kafka-ui 가 연겷할 브로커 주소
 
 volumes:
   mysql-8-data:
-  redis-data:
+  redis_master_data:
+  redis_readonly_data:
+  kafka-data:
 
 networks:
   default:

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `java-library`
+    `java-test-fixtures`
+    kotlin("jvm") version "2.0.20"
+}
+
+dependencies {
+    api("org.springframework.kafka:spring-kafka")
+
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation("org.testcontainers:kafka")
+
+    testFixturesImplementation("org.testcontainers:kafka")
+}

--- a/modules/kafka/build.gradle.kts
+++ b/modules/kafka/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     `java-test-fixtures`
     kotlin("jvm") version "2.0.20"
+    kotlin("plugin.spring") version "2.0.20"
 }
 
 dependencies {

--- a/modules/kafka/src/main/kotlin/com/loopers/config/kafka/KafkaConfig.kt
+++ b/modules/kafka/src/main/kotlin/com/loopers/config/kafka/KafkaConfig.kt
@@ -1,0 +1,83 @@
+package com.loopers.config.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.listener.ContainerProperties
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter
+import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter
+import java.util.HashMap
+
+@EnableKafka
+@Configuration
+class KafkaConfig {
+    companion object {
+        const val BATCH_LISTENER = "BATCH_LISTENER_DEFAULT"
+
+        private const val MAX_POLLING_SIZE = 3000 // read 3000 msg
+        private const val FETCH_MIN_BYTES = (1024 * 1024) // 1mb
+        private const val FETCH_MAX_WAIT_MS = 5 * 1000 // broker waiting time = 5s
+        private const val SESSION_TIMEOUT_MS = 60 * 1000 // session timeout = 1m
+        private const val HEARTBEAT_INTERVAL_MS = 20 * 1000 // heartbeat interval = 20s ( 1/3 of session_timeout )
+        private const val MAX_POLL_INTERVAL_MS = 2 * 60 * 1000 // max poll interval = 2m
+    }
+
+    @Bean
+    fun producerFactory(
+        kafkaProperties: KafkaProperties,
+    ): ProducerFactory<Any, Any> {
+        val props: Map<String, Any> = HashMap(kafkaProperties.buildProducerProperties())
+        return DefaultKafkaProducerFactory(props)
+    }
+
+    @Bean
+    fun consumerFactory(
+        kafkaProperties: KafkaProperties,
+    ): ConsumerFactory<Any, Any> {
+        val props: Map<String, Any> = HashMap(kafkaProperties.buildConsumerProperties())
+        return DefaultKafkaConsumerFactory(props)
+    }
+
+    @Bean
+    fun kafkaTemplate(producerFactory: ProducerFactory<Any, Any>): KafkaTemplate<Any, Any> {
+        return KafkaTemplate(producerFactory)
+    }
+
+    @Bean
+    fun jsonMessageConverter(objectMapper: ObjectMapper): ByteArrayJsonMessageConverter {
+        return ByteArrayJsonMessageConverter(objectMapper)
+    }
+
+    @Bean(BATCH_LISTENER)
+    fun defaultBatchListenerContainerFactory(
+        kafkaProperties: KafkaProperties,
+        converter: ByteArrayJsonMessageConverter,
+    ): ConcurrentKafkaListenerContainerFactory<*, *> {
+        val consumerConfig = HashMap(kafkaProperties.buildConsumerProperties())
+            .apply {
+                put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, MAX_POLLING_SIZE)
+                put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, FETCH_MIN_BYTES)
+                put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, FETCH_MAX_WAIT_MS)
+                put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS)
+                put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, HEARTBEAT_INTERVAL_MS)
+                put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS)
+            }
+
+        return ConcurrentKafkaListenerContainerFactory<Any, Any>().apply {
+            consumerFactory = DefaultKafkaConsumerFactory(consumerConfig)
+            containerProperties.ackMode = ContainerProperties.AckMode.MANUAL
+            setBatchMessageConverter(BatchMessagingMessageConverter(converter))
+            setConcurrency(3)
+            isBatchListener = true
+        }
+    }
+}

--- a/modules/kafka/src/main/kotlin/com/loopers/config/kafka/KafkaConfig.kt
+++ b/modules/kafka/src/main/kotlin/com/loopers/config/kafka/KafkaConfig.kt
@@ -19,20 +19,20 @@ import java.util.HashMap
 
 @EnableKafka
 @Configuration
-class KafkaConfig {
+open class KafkaConfig {
     companion object {
         const val BATCH_LISTENER = "BATCH_LISTENER_DEFAULT"
 
-        private const val MAX_POLLING_SIZE = 3000 // read 3000 msg
-        private const val FETCH_MIN_BYTES = (1024 * 1024) // 1mb
-        private const val FETCH_MAX_WAIT_MS = 5 * 1000 // broker waiting time = 5s
-        private const val SESSION_TIMEOUT_MS = 60 * 1000 // session timeout = 1m
-        private const val HEARTBEAT_INTERVAL_MS = 20 * 1000 // heartbeat interval = 20s ( 1/3 of session_timeout )
-        private const val MAX_POLL_INTERVAL_MS = 2 * 60 * 1000 // max poll interval = 2m
+        private const val MAX_POLLING_SIZE = 3000 // 단일 폴링에서 읽을 최대 메시지 수: 3000건
+        private const val FETCH_MIN_BYTES = (1024 * 1024) // 최소 페치 크기: 1MB
+        private const val FETCH_MAX_WAIT_MS = 5 * 1000 // 브로커 대기 시간: 5초
+        private const val SESSION_TIMEOUT_MS = 60 * 1000 // 세션 타임아웃: 1분
+        private const val HEARTBEAT_INTERVAL_MS = 20 * 1000 // 하트비트 간격: 20초 (세션 타임아웃의 1/3)
+        private const val MAX_POLL_INTERVAL_MS = 2 * 60 * 1000 // 최대 폴링 간격: 2분
     }
 
     @Bean
-    fun producerFactory(
+    open fun producerFactory(
         kafkaProperties: KafkaProperties,
     ): ProducerFactory<Any, Any> {
         val props: Map<String, Any> = HashMap(kafkaProperties.buildProducerProperties())
@@ -40,7 +40,7 @@ class KafkaConfig {
     }
 
     @Bean
-    fun consumerFactory(
+    open fun consumerFactory(
         kafkaProperties: KafkaProperties,
     ): ConsumerFactory<Any, Any> {
         val props: Map<String, Any> = HashMap(kafkaProperties.buildConsumerProperties())
@@ -48,17 +48,17 @@ class KafkaConfig {
     }
 
     @Bean
-    fun kafkaTemplate(producerFactory: ProducerFactory<Any, Any>): KafkaTemplate<Any, Any> {
+    open fun kafkaTemplate(producerFactory: ProducerFactory<Any, Any>): KafkaTemplate<Any, Any> {
         return KafkaTemplate(producerFactory)
     }
 
     @Bean
-    fun jsonMessageConverter(objectMapper: ObjectMapper): ByteArrayJsonMessageConverter {
+    open fun jsonMessageConverter(objectMapper: ObjectMapper): ByteArrayJsonMessageConverter {
         return ByteArrayJsonMessageConverter(objectMapper)
     }
 
     @Bean(BATCH_LISTENER)
-    fun defaultBatchListenerContainerFactory(
+    open fun defaultBatchListenerContainerFactory(
         kafkaProperties: KafkaProperties,
         converter: ByteArrayJsonMessageConverter,
     ): ConcurrentKafkaListenerContainerFactory<*, *> {

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -1,0 +1,44 @@
+spring:
+  kafka:
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
+    client-id: ${spring.application.name}
+    properties:
+        spring.json.add.type.headers: false # json serialize off
+        request.timeout.ms: 20000
+        retry.backoff.ms: 500
+        auto:
+          create.topics.enable: false
+          register.schemas: false
+          offset.reset: latest
+        use.latest.version: true
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      retries: 3
+    consumer:
+      group-id: loopers-default-consumer
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-serializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+      properties:
+        enable-auto-commit: false
+    listener:
+      ack-mode: manual
+
+---
+spring.config.activate.on-profile: local, test
+
+spring:
+  kafka:
+    bootstrap-servers: localhost:19092
+    admin:
+      properties:
+        bootstrap.servers: kafka:9092
+
+---
+spring.config.activate.on-profile: dev
+
+---
+spring.config.activate.on-profile: qa
+
+---
+spring.config.activate.on-profile: prd

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -1,9 +1,9 @@
 spring:
   kafka:
-    bootstrap-servers: ${BOOTSTRAP_SERVERS}
+    bootstrap-servers: ${BOOTSTRAP_SERVERS:localhost:19092}
     client-id: ${spring.application.name}
     properties:
-        spring.json.add.type.headers: false # json serialize off
+        spring.json.add.type.headers: false # JSON 타입 헤더 비활성화
         request.timeout.ms: 20000
         retry.backoff.ms: 500
         auto:
@@ -32,7 +32,7 @@ spring:
     bootstrap-servers: localhost:19092
     admin:
       properties:
-        bootstrap.servers: kafka:9092
+        bootstrap.servers: localhost:19092
 
 ---
 spring.config.activate.on-profile: dev

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,10 @@ rootProject.name = "loopers-java-spring-template"
 
 include(
     ":apps:commerce-api",
+    ":apps:commerce-streamer",
     ":apps:pg-simulator",
     ":modules:jpa",
+    ":modules:kafka",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",


### PR DESCRIPTION
## 📌 Summary
Spring Boot + Apache Kafka를 활용한 이벤트 드리븐 파이프라인을 구축했습니다.
- **Producer**: commerce-api에서 도메인 이벤트를 catalog-events, order-events 토픽으로 발행
- **Consumer**: commerce-streamer에서 3가지 용도로 이벤트 처리 (감사 로그, 캐시 무효화, 메트릭 집계)
- **핵심 기능**: PartitionKey 기반 순서 보장, 멱등성 처리, 장애 격리

## 💬 Review Points

### 1. 파티션 키 설계 검토
- productId를 파티션 키로 사용한 순서 보장 로직이 적절한지 확인 부탁드립니다

### 2. 멱등성 처리 로직
- `IdempotentEventService`의 트랜잭션 처리가 올바른지 확인 부탁드립니다


### 4. 성능 최적화 설정
- Kafka Consumer 배치 처리 설정값들(MAX_POLLING_SIZE: 3000, FETCH_MIN_BYTES: 1MB)이 적절한지 확인 부탁드립니다


## ✅ Checklist

### 🎾 Producer
- [x] 도메인(애플리케이션) 이벤트 설계 8d55a3babf717d3f54f77f7b2359513dbda8b569
- [x] Producer 앱에서 도메인 이벤트 발행 (catalog-events, order-events, 등) d4b78a42e66490fbf5a49fb01d0fda6a498b1728
- [x] **PartitionKey** 기반의 이벤트 순서 보장 0eb46253210af7dfde280c04c295c9729120baf5
- [x] 메세지 발행이 실패했을 경우에 대해 고민해보기

### ⚾ Consumer
- [x] Consumer 앱에서 3종 처리 (Audit Log / Cache Evict / Metrics 집계) 21f35353fa3d41fce2fd747b9a41789784c5f8c0 
- [x] `event_handled` 테이블을 통한 멱등 처리 구현 b11c2887992c79c37242bb10652ec83e401c295e
- [x] 재고 소진 시 상품 캐시 삭제 25aa16487f7dc82020c5aaaf663368c170990f6a
- [x] 중복 메세지 재전송 테스트 → 최종 결과가 한 번만 반영되는지 확인 8c2055a9c0e13ff20e4f208dea29664f4b7ad214

## 📎 References
